### PR TITLE
Fixed highlighting bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function Board({xIsNext, squares, onPlay}) {
     }
 
     const [winner, winningLine] = calculateWinner(squares);
-    const isDraw = !squares.includes(null);
+    const isDraw = !winner && !squares.includes(null);
     const statusText = winner ? `Winner: ${winner}` : (isDraw ? 'Draw!' : `Next player: ${xIsNext ? "X" : "O"}`); 
 
     const boardRows = [];


### PR DESCRIPTION
The highlighting for the draw logic was overriding that for highlighting the winner. Fixed that by checking if there is no winner AND if there are no empty squares.